### PR TITLE
Adding workspace for refactored EDA code

### DIFF
--- a/combined_data.ipynb
+++ b/combined_data.ipynb
@@ -43,6 +43,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Movie Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Economics Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Combining Data"
    ]
   },
@@ -299,9 +327,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "ai_dev",
    "language": "python",
-   "name": "python3"
+   "name": "ai_dev"
   },
   "language_info": {
    "codemirror_mode": {
@@ -313,7 +341,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.1"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Added Markdown and Python cells for refactored EDA code, please merge with `main` to give Odele and Kalvin room in the final `*.ipynb` for cleaned code.